### PR TITLE
Switch drawing conversion to FLUX.1 Kontext Pro on Replicate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AI Coloring Book (susieqsbooks.org)
 
-Kids upload drawings → AI (Replicate ControlNet-scribble) turns them into
+Kids upload drawings → AI (Replicate FLUX.1 Kontext Pro) turns them into
 coloring-book pages → local sponsors pay via PayPal for logo placement →
 admin generates the printed-book PDF. Part fundraiser, part classroom
 activity for the nonprofit Susie Q's Kids. Serves Warren/Sterling Heights MI
@@ -50,8 +50,9 @@ and greater Phoenix AZ.
   known follow-up; never copy those values anywhere.
 - Prod log "You did not pass a valid authentication token" = Replicate 401
   (bad `REPLICATE_TOKEN` fly secret; 500s `/api/upload_drawings/`), not Django auth.
-- `/api/upload_drawings/` blocks the request on Replicate (30–120s on cold
-  boot) — gunicorn `--timeout 180` in the backend Dockerfile must stay ≥ that;
-  moving generation async (Replicate webhooks) is the durable fix.
+- `/api/upload_drawings/` blocks the request on Replicate (flux-kontext-pro
+  is always-on, typically 5–15s, but slow runs happen) — keep gunicorn
+  `--timeout 180` in the backend Dockerfile as headroom; moving generation
+  async (Replicate webhooks) is still the durable fix.
 - `frontend/nextapp/Dockerfile` + `fly.toml` are legacy; delete after the
   susieqsbooks.org DNS cutover to Vercel is verified.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Here's an overview of the components used:
 The backend solution includes:
 - Django
 - PostgresSQL
-- Model to convert scribbles to sketches: ControlNet (Modified Diffusion Model)
+- Model to convert scribbles to sketches: FLUX.1 Kontext Pro (originally ControlNet-scribble)
 - Model hosting platform: Replicate
 
 The frontend solution includes:

--- a/backend/suzie_api/Dockerfile
+++ b/backend/suzie_api/Dockerfile
@@ -24,6 +24,6 @@ COPY . /code
 
 EXPOSE 8000
 
-# --timeout must exceed a cold-boot Replicate run (upload_drawings blocks on it);
+# --timeout must comfortably exceed a slow Replicate run (upload_drawings blocks on it);
 # threads keep other requests flowing while a worker waits on Replicate.
 CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "--threads", "4", "--timeout", "180", "suzie_api.wsgi"]

--- a/backend/suzie_api/api/views.py
+++ b/backend/suzie_api/api/views.py
@@ -66,19 +66,26 @@ class CreateDrawingsViewSet(viewsets.ModelViewSet):
 
         raw_sketch = request.data["image"]
         subject = request.data["subject"]
-        prompt = f"{subject} as simple coloring book page"
+        prompt = (
+            f"Convert this child's drawing of {subject} into a coloring book page: "
+            "clean smooth black outlines on a pure white background, no color, "
+            "no shading, no gray fills. Keep the original composition and shapes "
+            "exactly as drawn."
+        )
 
         uploader = S3Handler(os.getenv("AWS_BUCKET"))
         ts = int(datetime.datetime.now().timestamp())
 
         raw_sketch.file.seek(0)
         file_content = raw_sketch.file.read()
-        # copy_of_file = BytesIO(file_content)
-        # copy_of_file.seek(0)
 
         creative_url = uploader.upload_file_to_s3(BytesIO(file_content), f'raw_sketch/{ts}.jpg')
 
-        processed_sketch = self.convert_file_to_color_book_sketch(raw_sketch.file, prompt)
+        # Fresh copy for Replicate: the S3 upload above consumed raw_sketch.file,
+        # and the client needs a filename to pick the right mime type.
+        sketch_copy = BytesIO(file_content)
+        sketch_copy.name = getattr(raw_sketch, "name", None) or "drawing.jpg"
+        processed_sketch = self.convert_file_to_color_book_sketch(sketch_copy, prompt)
         ai_creative_url = uploader.upload_url_to_s3(processed_sketch, f'ai/{ts}.jpg')
 
         sanitized_data = {
@@ -97,19 +104,19 @@ class CreateDrawingsViewSet(viewsets.ModelViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
     def convert_file_to_color_book_sketch(self, raw_sketch, prompt) -> str:
-        client = replicate.Client(os.getenv("REPLICATE_TOKEN"))
-        output = client.run(
-            "jagilley/controlnet-scribble:435061a1b5a4c1e26740464bf786efdfa9cb3a3ac488595a2de23e143fdb0117",
-            input={"image": raw_sketch,
-                   "prompt": prompt,
-                   "ddim_steps": 20,
-                   "scale": 8,
-                   "a_prompt": "best quality, line sketch, outlines only, black and white",
-                   "n_prompt": "solid fills, incomplete shapes"}
+        client = replicate.Client(api_token=os.getenv("REPLICATE_TOKEN"))
+        # flux-kontext-pro is an official always-on Replicate model: no version
+        # hash, no cold boots, flat per-image pricing, single-URL output.
+        return client.run(
+            "black-forest-labs/flux-kontext-pro",
+            input={
+                "input_image": raw_sketch,
+                "prompt": prompt,
+                "aspect_ratio": "match_input_image",
+                "output_format": "png",
+            },
+            use_file_output=False,  # upload_url_to_s3 expects a plain URL string
         )
-        raw_img, ai_generated = output
-        # ai_generated = "https://pbxt.replicate.delivery/slwfP9Un21TMfUDIupiu3tEMhGlaSkegDjF6xX2SDWl6flvGB/output_1.png"
-        return ai_generated
 
 
 class NonProfitsViewSet(viewsets.ModelViewSet):

--- a/backend/suzie_api/requirements.txt
+++ b/backend/suzie_api/requirements.txt
@@ -27,7 +27,7 @@ PyJWT==2.8.0
 python-dateutil==2.8.2
 python-dotenv==1.0.0
 pytz==2023.3.post1
-replicate==0.15.3
+replicate==1.0.7
 requests==2.31.0
 s3transfer==0.7.0
 six==1.16.0


### PR DESCRIPTION
Replace the 2023-era jagilley/controlnet-scribble (SD 1.5, 512px,
community model with 30-120s cold boots) with
black-forest-labs/flux-kontext-pro, an official always-on Replicate
model built for instruction-based image editing. Kontext preserves the
child's original composition while converting it to clean black-and-white
outlines, runs in ~5-15s with no cold boots, and costs a flat $0.04/image.

- Bump replicate client 0.15.3 -> 1.0.7 (required for version-less
  official-model runs); pinned httpx/pydantic deps are compatible.
- Pass use_file_output=False so the S3 uploader keeps getting a plain
  URL string.
- Rewrite the prompt as an edit instruction and send Replicate a fresh
  named BytesIO copy (the S3 upload consumes the original file handle).
- Update CLAUDE.md, README, and Dockerfile notes that documented the
  old cold-boot behavior.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EEdnXDdzZQcGDfnC347rnh