### PR TITLE
Show all users to site admins on the Users tab

### DIFF
--- a/backend/suzie_api/api/serializers.py
+++ b/backend/suzie_api/api/serializers.py
@@ -96,12 +96,23 @@ class UserLoginSerializer(serializers.Serializer):
 
 
 class UserListSerializer(serializers.ModelSerializer):
+    # Sponsors keep their organization on the Sponsors table, not the user row.
+    organization = serializers.SerializerMethodField()
+
     class Meta:
-        model = settings.AUTH_USER_MODEL
+        model = UserModel
         fields = (
+            'id',
             'email',
-            'role'
+            'role',
+            'school',
+            'organization',
+            'date_joined'
         )
+
+    def get_organization(self, obj):
+        sponsor = obj.sponsors_set.first()
+        return sponsor.name if sponsor else None
 
 
 class DrawingsGetSerializer(serializers.ModelSerializer):

--- a/backend/suzie_api/api/views.py
+++ b/backend/suzie_api/api/views.py
@@ -459,22 +459,13 @@ class UserListView(APIView):
     permission_classes = (IsAdmin,)
 
     def get(self, request):
-        user = request.user
-        if user.role != 1:
-            response = {
-                'success': False,
-                'status_code': status.HTTP_403_FORBIDDEN,
-                'message': 'You are not authorized to perform this action'
-            }
-            return Response(response, status.HTTP_403_FORBIDDEN)
-        else:
-            users = UserModel.objects.all()
-            serializer = self.serializer_class(users, many=True)
-            response = {
-                'success': True,
-                'status_code': status.HTTP_200_OK,
-                'message': 'Successfully fetched users',
-                'users': serializer.data
-
-            }
-            return Response(response, status=status.HTTP_200_OK)
+        # IsAdmin already guarantees a site admin (role 1) is calling.
+        users = UserModel.objects.all().order_by('role', 'email')
+        serializer = self.serializer_class(users, many=True)
+        response = {
+            'success': True,
+            'status_code': status.HTTP_200_OK,
+            'message': 'Successfully fetched users',
+            'users': serializer.data
+        }
+        return Response(response, status=status.HTTP_200_OK)

--- a/frontend/nextapp/src/components/users/Users.js
+++ b/frontend/nextapp/src/components/users/Users.js
@@ -1,12 +1,13 @@
 "use client";
-import { useState } from 'react';
-import { Alert, Button, PasswordInput, Select, TextInput } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { Alert, Badge, Button, PasswordInput, Select, Skeleton, Table, TextInput } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import styles from "./users.module.css";
 import chrome from '@/components/admin/page-chrome.module.css';
-import { registerUser } from '@/lib/api';
+import { getUsers, registerUser } from '@/lib/api';
 import { ROLES } from '@/lib/auth';
 import { SCHOOL_GROUPS } from '@/data/schools';
+import { formatShortDate } from '@/lib/dates';
 
 const ROLE_OPTIONS = {
     'Admin': ROLES.ADMIN,
@@ -14,7 +15,15 @@ const ROLE_OPTIONS = {
     'Sponsor': ROLES.SPONSOR,
 };
 
+const ROLE_BADGES = {
+    [ROLES.ADMIN]: { label: 'Admin', color: 'brand' },
+    [ROLES.SCHOOL_ADMIN]: { label: 'School admin', color: 'sunshine' },
+    [ROLES.SPONSOR]: { label: 'Sponsor', color: 'gray' },
+};
+
 export default function Users({ notify }) {
+    const [users, setUsers] = useState([]);
+    const [isLoadingUsers, setIsLoadingUsers] = useState(true);
     const [role, setRole] = useState('');
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
@@ -23,6 +32,23 @@ export default function Users({ notify }) {
     const [school, setSchool] = useState(null);
     const [error, setError] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const fetchUsers = async () => {
+        try {
+            const response = await getUsers();
+            setUsers(response.data.users || []);
+        } catch (err) {
+            console.error('Failed to fetch users:', err);
+            notify('Could not load the user list. Please refresh and try again.', 'error');
+        } finally {
+            setIsLoadingUsers(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchUsers();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleSubmit = async (event) => {
         event.preventDefault();
@@ -55,6 +81,7 @@ export default function Users({ notify }) {
             setConfirmPassword('');
             setOrganization('');
             setSchool(null);
+            fetchUsers();
         } catch (err) {
             console.error('Error:', err);
             setError('Could not create the user. Please check the details and try again.');
@@ -63,78 +90,134 @@ export default function Users({ notify }) {
         }
     };
 
+    const renderUserList = () => {
+        if (isLoadingUsers) {
+            return <Skeleton height={220} radius={12} />;
+        }
+
+        if (users.length === 0) {
+            return (
+                <div className={chrome.emptyState}>
+                    <p className={chrome.emptyTitle}>No users yet</p>
+                    <p className={chrome.emptyText}>
+                        Create the first account with the form.
+                    </p>
+                </div>
+            );
+        }
+
+        return (
+            <div className={styles.tableCard}>
+                <Table verticalSpacing="sm" highlightOnHover>
+                    <Table.Thead>
+                        <Table.Tr>
+                            <Table.Th>Email</Table.Th>
+                            <Table.Th>Role</Table.Th>
+                            <Table.Th>School / organization</Table.Th>
+                            <Table.Th>Added</Table.Th>
+                        </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
+                        {users.map((user) => {
+                            const badge = ROLE_BADGES[user.role] || { label: 'Unknown', color: 'gray' };
+                            return (
+                                <Table.Tr key={user.id}>
+                                    <Table.Td className={styles.emailCell}>{user.email}</Table.Td>
+                                    <Table.Td>
+                                        <Badge variant="light" color={badge.color}>
+                                            {badge.label}
+                                        </Badge>
+                                    </Table.Td>
+                                    <Table.Td>{user.school || user.organization || '—'}</Table.Td>
+                                    <Table.Td>
+                                        {user.date_joined ? formatShortDate(user.date_joined) : '—'}
+                                    </Table.Td>
+                                </Table.Tr>
+                            );
+                        })}
+                    </Table.Tbody>
+                </Table>
+            </div>
+        );
+    };
+
     return (
         <section>
             <header className={chrome.pageHead}>
                 <h1 className={chrome.pageTitle}>Users</h1>
                 <p className={chrome.pageSub}>
-                    Create sign-ins for other admins, or for sponsors who want to
-                    follow the books they&apos;ve supported.
+                    Everyone who can sign in, and a form to add more — other admins,
+                    school admins, or sponsors who want to follow their books.
                 </p>
             </header>
 
-            <form onSubmit={handleSubmit} className={styles.card}>
-                <Select
-                    label="Role"
-                    placeholder="Choose a role"
-                    description="Admins manage everything; school admins manage one school's drawings and books; sponsors only see their books."
-                    data={Object.keys(ROLE_OPTIONS)}
-                    value={role}
-                    onChange={setRole}
-                    required
-                />
-                {role === 'School admin' && (
+            <div className={styles.layout}>
+                <div className={styles.listColumn}>{renderUserList()}</div>
+
+                <form onSubmit={handleSubmit} className={styles.card}>
+                    <h2 className={styles.formTitle}>Create a user</h2>
                     <Select
-                        label="School"
-                        placeholder="Pick their school"
-                        description="They'll only see drawings and books for this school."
-                        data={SCHOOL_GROUPS}
-                        value={school}
-                        onChange={setSchool}
-                        searchable
+                        label="Role"
+                        placeholder="Choose a role"
+                        description="Admins manage everything; school admins manage one school's drawings and books; sponsors only see their books."
+                        data={Object.keys(ROLE_OPTIONS)}
+                        value={role}
+                        onChange={setRole}
                         required
                     />
-                )}
-                <TextInput
-                    label="Email"
-                    type="email"
-                    placeholder="name@example.org"
-                    autoComplete="off"
-                    required
-                    value={email}
-                    onChange={(e) => setEmail(e.currentTarget.value)}
-                />
-                <PasswordInput
-                    label="Password"
-                    autoComplete="new-password"
-                    required
-                    value={password}
-                    onChange={(e) => setPassword(e.currentTarget.value)}
-                />
-                <PasswordInput
-                    label="Confirm password"
-                    autoComplete="new-password"
-                    required
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.currentTarget.value)}
-                />
-                <TextInput
-                    label="Organization"
-                    placeholder="Business or group name"
-                    description="Only needed for sponsors."
-                    value={organization}
-                    onChange={(e) => setOrganization(e.currentTarget.value)}
-                    disabled={role !== "Sponsor"}
-                />
-                {error && (
-                    <Alert color="red" variant="light" icon={<IconAlertCircle size={16} />}>
-                        {error}
-                    </Alert>
-                )}
-                <Button type="submit" loading={isSubmitting} className={styles.submit}>
-                    Create user
-                </Button>
-            </form>
+                    {role === 'School admin' && (
+                        <Select
+                            label="School"
+                            placeholder="Pick their school"
+                            description="They'll only see drawings and books for this school."
+                            data={SCHOOL_GROUPS}
+                            value={school}
+                            onChange={setSchool}
+                            searchable
+                            required
+                        />
+                    )}
+                    <TextInput
+                        label="Email"
+                        type="email"
+                        placeholder="name@example.org"
+                        autoComplete="off"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.currentTarget.value)}
+                    />
+                    <PasswordInput
+                        label="Password"
+                        autoComplete="new-password"
+                        required
+                        value={password}
+                        onChange={(e) => setPassword(e.currentTarget.value)}
+                    />
+                    <PasswordInput
+                        label="Confirm password"
+                        autoComplete="new-password"
+                        required
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.currentTarget.value)}
+                    />
+                    <TextInput
+                        label="Organization"
+                        placeholder="Business or group name"
+                        description="Only needed for sponsors."
+                        value={organization}
+                        onChange={(e) => setOrganization(e.currentTarget.value)}
+                        disabled={role !== "Sponsor"}
+                    />
+                    {error && (
+                        <Alert color="red" variant="light" icon={<IconAlertCircle size={16} />}>
+                            {error}
+                        </Alert>
+                    )}
+                    <Button type="submit" loading={isSubmitting} className={styles.submit}>
+                        Create user
+                    </Button>
+                </form>
+            </div>
         </section>
     );
 }

--- a/frontend/nextapp/src/components/users/__tests__/Users.test.js
+++ b/frontend/nextapp/src/components/users/__tests__/Users.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils/render";
+import Users from "@/components/users/Users";
+
+const getUsers = vi.fn();
+const registerUser = vi.fn();
+vi.mock("@/lib/api", () => ({
+  getUsers: (...args) => getUsers(...args),
+  registerUser: (...args) => registerUser(...args),
+}));
+
+const USERS_RESPONSE = {
+  data: {
+    users: [
+      { id: 1, email: "mary@susieqskids.org", role: 1, school: null, organization: null, date_joined: "2024-02-16T12:00:00" },
+      { id: 9, email: "teacher@susick.org", role: 3, school: "Margaret I. Susick Elementary School", organization: null, date_joined: "2026-07-23T12:00:00" },
+      { id: 12, email: "owner@warrenpizza.com", role: 2, school: null, organization: "Warren Pizza Co.", date_joined: "2026-07-01T12:00:00" },
+    ],
+  },
+};
+
+describe("Users", () => {
+  beforeEach(() => {
+    getUsers.mockClear();
+    registerUser.mockClear();
+    getUsers.mockResolvedValue(USERS_RESPONSE);
+  });
+
+  it("lists every account with role badges and school/organization", async () => {
+    render(<Users notify={vi.fn()} />);
+
+    expect(await screen.findByText("mary@susieqskids.org")).toBeInTheDocument();
+    expect(screen.getByText("teacher@susick.org")).toBeInTheDocument();
+    expect(screen.getByText("owner@warrenpizza.com")).toBeInTheDocument();
+    expect(screen.getAllByText("School admin").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Sponsor").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Margaret I. Susick Elementary School")).toBeInTheDocument();
+    expect(screen.getByText("Warren Pizza Co.")).toBeInTheDocument();
+  });
+
+  it("notifies when the list cannot load", async () => {
+    getUsers.mockRejectedValue(new Error("boom"));
+    const notify = vi.fn();
+    render(<Users notify={notify} />);
+
+    await vi.waitFor(() =>
+      expect(notify).toHaveBeenCalledWith(
+        "Could not load the user list. Please refresh and try again.",
+        "error"
+      )
+    );
+  });
+
+  it("creates a school admin with a school and refreshes the list", async () => {
+    registerUser.mockResolvedValue({ data: { success: true } });
+    const notify = vi.fn();
+    render(<Users notify={notify} />);
+    await screen.findByText("mary@susieqskids.org");
+
+    await userEvent.click(screen.getByPlaceholderText("Choose a role"));
+    await userEvent.click(screen.getByRole("option", { name: "School admin" }));
+    await userEvent.click(screen.getByPlaceholderText("Pick their school"));
+    await userEvent.click(
+      screen.getByRole("option", { name: "Maurice M. Wilde Elementary School" })
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText("name@example.org"),
+      "newadmin@wilde.org"
+    );
+    const [password, confirm] = screen.getAllByLabelText(/password/i);
+    await userEvent.type(password, "hunter22");
+    await userEvent.type(confirm, "hunter22");
+    await userEvent.click(screen.getByRole("button", { name: "Create user" }));
+
+    expect(registerUser).toHaveBeenCalledWith({
+      email: "newadmin@wilde.org",
+      password: "hunter22",
+      role: 3,
+      organization: "",
+      school: "Maurice M. Wilde Elementary School",
+    });
+    // Initial load + refresh after create.
+    await vi.waitFor(() => expect(getUsers).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/nextapp/src/components/users/users.module.css
+++ b/frontend/nextapp/src/components/users/users.module.css
@@ -1,15 +1,57 @@
+.layout {
+    display: flex;
+    gap: 1.5rem;
+    align-items: flex-start;
+}
+
+.listColumn {
+    flex: 1;
+    min-width: 0;
+}
+
+.tableCard {
+    background: #fff;
+    border: 2px solid var(--ink);
+    border-radius: 14px;
+    overflow-x: auto;
+}
+
+.emailCell {
+    font-weight: 600;
+    color: var(--ink);
+    word-break: break-all;
+}
+
 .card {
     background: #fff;
     border: 2px solid var(--ink);
     border-radius: 14px;
     padding: 1.75rem 1.5rem;
-    max-width: 460px;
+    width: 100%;
+    max-width: 380px;
     display: flex;
     flex-direction: column;
     gap: 0.9rem;
 }
 
+.formTitle {
+    font-family: var(--font-fredoka), sans-serif;
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--ink);
+}
+
 .submit {
     align-self: flex-start;
     margin-top: 0.25rem;
+}
+
+@media (max-width: 900px) {
+    .layout {
+        flex-direction: column;
+    }
+
+    .card {
+        max-width: 460px;
+    }
 }

--- a/frontend/nextapp/src/lib/__tests__/dates.test.js
+++ b/frontend/nextapp/src/lib/__tests__/dates.test.js
@@ -1,10 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { formatBookDate } from "@/lib/dates";
+import { formatBookDate, formatShortDate } from "@/lib/dates";
 
 describe("formatBookDate", () => {
   it("formats an ISO UTC timestamp into a friendly local date", () => {
     // Assert on the stable parts rather than the timezone-dependent time.
     const formatted = formatBookDate("2024-04-06T23:09:15.625779");
     expect(formatted).toMatch(/^[A-Z][a-z]{2} \d{1,2}(st|nd|rd|th) 2024 \d{1,2}:\d{2}(am|pm)$/);
+  });
+});
+
+describe("formatShortDate", () => {
+  it("formats an ISO UTC timestamp into a short local date", () => {
+    const formatted = formatShortDate("2024-04-06T12:00:00");
+    expect(formatted).toMatch(/^[A-Z][a-z]{2} \d{1,2}, 2024$/);
   });
 });

--- a/frontend/nextapp/src/lib/api.js
+++ b/frontend/nextapp/src/lib/api.js
@@ -33,6 +33,8 @@ export const login = (email, password) =>
 
 export const registerUser = (data) => api.post("/api/register", data);
 
+export const getUsers = () => api.get("/api/users");
+
 export const getDrawings = () => api.get("/api/drawings/");
 
 // FormData: let axios set the multipart boundary itself.

--- a/frontend/nextapp/src/lib/dates.js
+++ b/frontend/nextapp/src/lib/dates.js
@@ -8,3 +8,7 @@ dayjs.extend(advancedFormat);
 export function formatBookDate(isoUtc) {
   return dayjs.utc(isoUtc).local().format("MMM Do YYYY h:mma");
 }
+
+export function formatShortDate(isoUtc) {
+  return dayjs.utc(isoUtc).local().format("MMM D, YYYY");
+}


### PR DESCRIPTION
GET /api/users was gated to site admins but broken (serializer referenced the model by settings string) and unused. Fix the serializer (id, email, role, school, sponsor organization, date joined), drop the redundant request.user role check that 500'd under the custom JWT permission, and render the list in the dashboard Users tab as a table with role badges beside the create form, refreshing after each new account. School admins still never see this tab and the endpoint rejects them.