### PR TITLE
Show last login on the dashboard Users tab

### DIFF
--- a/backend/suzie_api/api/serializers.py
+++ b/backend/suzie_api/api/serializers.py
@@ -107,7 +107,8 @@ class UserListSerializer(serializers.ModelSerializer):
             'role',
             'school',
             'organization',
-            'date_joined'
+            'date_joined',
+            'last_login'
         )
 
     def get_organization(self, obj):

--- a/frontend/nextapp/src/components/users/Users.js
+++ b/frontend/nextapp/src/components/users/Users.js
@@ -7,7 +7,7 @@ import chrome from '@/components/admin/page-chrome.module.css';
 import { getUsers, registerUser } from '@/lib/api';
 import { ROLES } from '@/lib/auth';
 import { SCHOOL_GROUPS } from '@/data/schools';
-import { formatShortDate } from '@/lib/dates';
+import { formatBookDate, formatRelativeDate, formatShortDate } from '@/lib/dates';
 
 const ROLE_OPTIONS = {
     'Admin': ROLES.ADMIN,
@@ -114,6 +114,7 @@ export default function Users({ notify }) {
                             <Table.Th>Email</Table.Th>
                             <Table.Th>Role</Table.Th>
                             <Table.Th>School / organization</Table.Th>
+                            <Table.Th>Last login</Table.Th>
                             <Table.Th>Added</Table.Th>
                         </Table.Tr>
                     </Table.Thead>
@@ -129,6 +130,15 @@ export default function Users({ notify }) {
                                         </Badge>
                                     </Table.Td>
                                     <Table.Td>{user.school || user.organization || '—'}</Table.Td>
+                                    <Table.Td>
+                                        {user.last_login ? (
+                                            <span title={formatBookDate(user.last_login)}>
+                                                {formatRelativeDate(user.last_login)}
+                                            </span>
+                                        ) : (
+                                            <span className={styles.never}>Never</span>
+                                        )}
+                                    </Table.Td>
                                     <Table.Td>
                                         {user.date_joined ? formatShortDate(user.date_joined) : '—'}
                                     </Table.Td>

--- a/frontend/nextapp/src/components/users/__tests__/Users.test.js
+++ b/frontend/nextapp/src/components/users/__tests__/Users.test.js
@@ -13,9 +13,9 @@ vi.mock("@/lib/api", () => ({
 const USERS_RESPONSE = {
   data: {
     users: [
-      { id: 1, email: "mary@susieqskids.org", role: 1, school: null, organization: null, date_joined: "2024-02-16T12:00:00" },
-      { id: 9, email: "teacher@susick.org", role: 3, school: "Margaret I. Susick Elementary School", organization: null, date_joined: "2026-07-23T12:00:00" },
-      { id: 12, email: "owner@warrenpizza.com", role: 2, school: null, organization: "Warren Pizza Co.", date_joined: "2026-07-01T12:00:00" },
+      { id: 1, email: "mary@susieqskids.org", role: 1, school: null, organization: null, date_joined: "2024-02-16T12:00:00", last_login: "2026-07-26T12:00:00" },
+      { id: 9, email: "teacher@susick.org", role: 3, school: "Margaret I. Susick Elementary School", organization: null, date_joined: "2026-07-23T12:00:00", last_login: null },
+      { id: 12, email: "owner@warrenpizza.com", role: 2, school: null, organization: "Warren Pizza Co.", date_joined: "2026-07-01T12:00:00", last_login: "2026-07-02T12:00:00" },
     ],
   },
 };
@@ -37,6 +37,16 @@ describe("Users", () => {
     expect(screen.getAllByText("Sponsor").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Margaret I. Susick Elementary School")).toBeInTheDocument();
     expect(screen.getByText("Warren Pizza Co.")).toBeInTheDocument();
+  });
+
+  it("shows last login as relative time, or Never for accounts that haven't signed in", async () => {
+    render(<Users notify={vi.fn()} />);
+
+    await screen.findByText("mary@susieqskids.org");
+    expect(screen.getByText("Last login")).toBeInTheDocument();
+    expect(screen.getByText("Never")).toBeInTheDocument();
+    // Relative dates like "a day ago" / "5 days ago" — assert the suffix.
+    expect(screen.getAllByText(/ago$/).length).toBeGreaterThanOrEqual(2);
   });
 
   it("notifies when the list cannot load", async () => {

--- a/frontend/nextapp/src/components/users/users.module.css
+++ b/frontend/nextapp/src/components/users/users.module.css
@@ -22,6 +22,11 @@
     word-break: break-all;
 }
 
+.never {
+    color: #a5a5ad;
+    font-style: italic;
+}
+
 .card {
     background: #fff;
     border: 2px solid var(--ink);

--- a/frontend/nextapp/src/lib/__tests__/dates.test.js
+++ b/frontend/nextapp/src/lib/__tests__/dates.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatBookDate, formatShortDate } from "@/lib/dates";
+import { formatBookDate, formatRelativeDate, formatShortDate } from "@/lib/dates";
 
 describe("formatBookDate", () => {
   it("formats an ISO UTC timestamp into a friendly local date", () => {
@@ -13,5 +13,11 @@ describe("formatShortDate", () => {
   it("formats an ISO UTC timestamp into a short local date", () => {
     const formatted = formatShortDate("2024-04-06T12:00:00");
     expect(formatted).toMatch(/^[A-Z][a-z]{2} \d{1,2}, 2024$/);
+  });
+});
+
+describe("formatRelativeDate", () => {
+  it("renders past timestamps relative to now", () => {
+    expect(formatRelativeDate("2024-04-06T12:00:00")).toMatch(/ago$/);
   });
 });

--- a/frontend/nextapp/src/lib/dates.js
+++ b/frontend/nextapp/src/lib/dates.js
@@ -1,9 +1,11 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import advancedFormat from "dayjs/plugin/advancedFormat";
+import relativeTime from "dayjs/plugin/relativeTime";
 
 dayjs.extend(utc);
 dayjs.extend(advancedFormat);
+dayjs.extend(relativeTime);
 
 export function formatBookDate(isoUtc) {
   return dayjs.utc(isoUtc).local().format("MMM Do YYYY h:mma");
@@ -11,4 +13,8 @@ export function formatBookDate(isoUtc) {
 
 export function formatShortDate(isoUtc) {
   return dayjs.utc(isoUtc).local().format("MMM D, YYYY");
+}
+
+export function formatRelativeDate(isoUtc) {
+  return dayjs.utc(isoUtc).local().fromNow();
 }


### PR DESCRIPTION
## Summary
- Adds `last_login` (already recorded by Django's `update_last_login` on every login) to the site-admin-only `GET /api/users` response.
- The Users tab table gets a "Last login" column rendered as relative time ("2 hours ago") with the exact timestamp on hover, and an italic "Never" for accounts that have never signed in.

## Test plan
- [x] `npm test` — 56 tests pass (new: relative-time formatter, Never fallback, column rendering)
- [x] `next build` passes
- [x] Serializer fields verified via Django shell
- Backend auto-deploys to fly on merge via the new workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)